### PR TITLE
Advertise support for Elasticsearch 8.18 and 9.0

### DIFF
--- a/modules/ROOT/pages/compatibility.adoc
+++ b/modules/ROOT/pages/compatibility.adoc
@@ -21,18 +21,12 @@ Windows is completely untested and unsupported.
 
 Elasticsearch version support is informed by https://www.elastic.co/support/eol[Elastic product end of life dates].
 
-[%autowidth,cols="^,6*^"]
+[%autowidth,cols="^,1*^"]
 |===
- |             6+h| Connector
-h| Elasticsearch↓ | 4.1 | 4.2.0 - 4.2.1 | 4.2.2 - 4.2.7 | 4.2.8 - 4.2.15 | 4.3 | 4.4
- | 8.0 - 8.16     | ✖   | ✖             | ✖             | ✖              | ✖   | ✔
- | 7.14 - 7.17    | ✖   | ✖             | ✖             | ✖              | ✔   | ✔
- | 7.12 - 7.13    | ✖   | ✖             | ✖             | ✖              | ✔   | ✖
- | 7.8 - 7.11     | ✖   | ✖             | ✖             | ✔              | ✔   | ✖
- | 7.6 - 7.7      | ✖   | ✖             | ◎             | ◎              | ◎   | ✖
- | 7.4 - 7.5      | ✖   | ◎             | ◎             | ◎              | ◎   | ✖
- | 6.8.17         | ✔   | ✔             | ✔             | ✔              | ✔   | ✖
- | 5.6.16         | ◎   | ◎             | ◎             | ◎              | ✖   | ✖
+ |             1+h| Connector
+h| Elasticsearch↓ | 4.4
+ | 8.0 - 9.0      | ✔
+ | 7.17           | ✔
 |===
 
 == OpenSearch
@@ -82,28 +76,27 @@ See xref:configuration.adoc#couchbase-capella[how to configure the connector for
 
 The connector is compatible with Couchbase Server Enterprise Edition and Couchbase Server Community Edition.
 
-[%autowidth,cols="^,3*^"]
+[%autowidth,cols="^,1*^"]
 |===
- |                   3+h| Connector
-h| Couchbase↓           | 4.1.0 - 4.2.1 | 4.2.2 - 4.3.0 | 4.3.1 and later
- | 7.0.2 and later      | ◎ *           | ✖             | ✔
- | 7.0.0 - 7.0.1        | ◎ *           | ✔             | ✔
- | 5.0 - 6.6            | ◎             | ◎             | ◎
- | < 5.0                | ✖             | ✖             | ✖
+ |                   1+h| Connector
+h| Couchbase↓           | 4.4
+ | 7.0 and later        | ✔
+ | 5.0 - 6.6            | ◎
+ | < 5.0                | ✖
 |===
 +++*+++ If you've been using an earlier version of Couchbase, you can upgrade to Couchbase 7 and everything will continue working as before.
 To take advantage of the Scopes and Collections introduced in Couchbase 7, please upgrade the connector to version 4.3 or later.
 
 == Java
 
-[%autowidth,cols="^,2*^"]
+Java 11 or later is required.
+
+[%autowidth,cols="^,1*^"]
 |===
- |                           2+h| Connector
-h| Java↓                        | 4.1 - 4.2 | 4.3 - 4.4
- | OpenJDK 17 (Eclipse Temurin) | ✔         | ✔
- | OpenJDK 11 (Eclipse Temurin) | ✔         | ✔
- | OpenJDK 8 (AdoptOpenJDK)     | ✔         | ✖
- | Oracle JDK 8                 | ✔         | ✖
+ |                           1+h| Connector
+h| Java↓                        | 4.4
+ | OpenJDK 17 (Eclipse Temurin) | ✔
+ | OpenJDK 11 (Eclipse Temurin) | ✔
 |===
 
 
@@ -111,18 +104,18 @@ h| Java↓                        | 4.1 - 4.2 | 4.3 - 4.4
 
 Only required for Autonomous Operations mode.
 
-[%autowidth,cols="^,3*^"]
+[%autowidth,cols="^,2*^"]
 |===
- |         3+h| Connector
-h| Consul↓    | 4.1 - 4.2.6  | 4.2.7 - 4.4.0 | 4.4.1 and later
- | 1.19.1     | ✖            | ✖             | ✔
- | 1.17.1     | ✖            | ✖             | ✔
- | 1.15.1     | ✖            | ✖             | ✔
- | 1.14.3     | ✖            | ✖             | ✔
- | 1.13.1     | ✖            | ✖             | ✔
- | 1.12.4     | ✖            | ✖             | ✔
- | 1.11.8     | ✖            | ✖             | ✔
- | 1.10.12    | ✖            | ✖             | ◎
- | 1.9.1      | ✖            | ✔             | ◎
- | 1.5.3      | ✔            | ✔             | ◎
+ |         2+h| Connector
+h| Consul↓    | 4.4.0 | 4.4.1 and later
+ | 1.19.1     | ✖     | ✔
+ | 1.17.1     | ✖     | ✔
+ | 1.15.1     | ✖     | ✔
+ | 1.14.3     | ✖     | ✔
+ | 1.13.1     | ✖     | ✔
+ | 1.12.4     | ✖     | ✔
+ | 1.11.8     | ✖     | ✔
+ | 1.10.12    | ✖     | ◎
+ | 1.9.1      | ✔     | ◎
+ | 1.5.3      | ✔     | ◎
 |===


### PR DESCRIPTION
And remove references to unsupported connector versions (everything prior to 4.4) and ES versions (everything prior to 7.17)